### PR TITLE
Use dart.library.js_interop for Wasm-ready conditional imports

### DIFF
--- a/vrchat_dart/example_flutter/lib/vrc_api_container.dart
+++ b/vrchat_dart/example_flutter/lib/vrc_api_container.dart
@@ -1,5 +1,5 @@
 import 'package:vrchat_dart_example_flutter/vrc_api_container_impl_native.dart'
-    if (dart.library.js) 'package:vrchat_dart_example_flutter/vrc_api_container_impl_web.dart';
+    if (dart.library.js_interop) 'package:vrchat_dart_example_flutter/vrc_api_container_impl_web.dart';
 import 'package:vrchat_dart/vrchat_dart.dart';
 
 /// Handle initializing the api between both native and web

--- a/vrchat_dart/lib/src/api/vrc_api_base.dart
+++ b/vrchat_dart/lib/src/api/vrc_api_base.dart
@@ -4,7 +4,7 @@ import 'package:vrchat_dart_generated/vrchat_dart_generated.dart';
 import 'package:vrchat_dart/src/api/src/auth_api.dart';
 import 'package:vrchat_dart/src/streaming/vrc_streaming.dart';
 import 'package:vrchat_dart/src/api/vrc_api_native.dart'
-    if (dart.library.js) 'package:vrchat_dart/src/api/vrc_api_web.dart';
+    if (dart.library.js_interop) 'package:vrchat_dart/src/api/vrc_api_web.dart';
 import 'package:meta/meta.dart';
 
 /// Shared code between the web and native implementations


### PR DESCRIPTION
## Summary
- Replace `dart.library.js` with `dart.library.js_interop` in web conditional imports so Wasm selects the web API implementation instead of the native/`dart:io` path.
- Fixes the missing 10 pub points from pana's Wasm compatibility check.

## Test plan
- [ ] `dart pub global run pana vrchat_dart` reports Wasm-ready / full platform points
- [ ] Existing native + web examples still initialize correctly